### PR TITLE
Add benchmark feature

### DIFF
--- a/admin.tsx
+++ b/admin.tsx
@@ -2,6 +2,13 @@ import React, { useEffect, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import "./admin.css";
 
+type BenchSummary = {
+  id: string;
+  status: string;
+  totalRounds: number;
+  completedRounds: number;
+} | null;
+
 type AdminSnapshot = {
   isPaused: boolean;
   isRunningRound: boolean;
@@ -9,6 +16,7 @@ type AdminSnapshot = {
   completedInMemory: number;
   persistedRounds: number;
   viewerCount: number;
+  bench?: BenchSummary;
 };
 
 type AdminResponse = { ok: true } & AdminSnapshot;
@@ -61,6 +69,7 @@ function App() {
   const [pending, setPending] = useState<string | null>(null);
   const [isResetOpen, setIsResetOpen] = useState(false);
   const [resetText, setResetText] = useState("");
+  const [benchRoundsPerPairing, setBenchRoundsPerPairing] = useState(1);
 
   useEffect(() => {
     let mounted = true;
@@ -173,6 +182,53 @@ function App() {
     }
   }
 
+  async function onBenchStart() {
+    setError(null);
+    setPending("bench-start");
+    try {
+      const response = await fetch("/api/bench/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ roundsPerPairing: benchRoundsPerPairing }),
+        cache: "no-store",
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(text || `Request failed (${response.status})`);
+      }
+      try {
+        const statusData = await requestAdminJson("/api/admin/status");
+        setSnapshot(statusData);
+      } catch {}
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start benchmark");
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function onBenchCancel() {
+    setError(null);
+    setPending("bench-cancel");
+    try {
+      const response = await fetch("/api/bench/cancel", {
+        method: "POST",
+        cache: "no-store",
+      });
+      if (!response.ok) {
+        throw new Error(await readErrorMessage(response));
+      }
+      try {
+        const statusData = await requestAdminJson("/api/admin/status");
+        setSnapshot(statusData);
+      } catch {}
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to cancel benchmark");
+    } finally {
+      setPending(null);
+    }
+  }
+
   async function onLogout() {
     setError(null);
     setPending("logout");
@@ -263,6 +319,7 @@ function App() {
         <nav className="quick-links">
           <a href="/">Live Game</a>
           <a href="/history">History</a>
+          <a href="/bench">Bench</a>
           <button className="link-button" onClick={onLogout} disabled={busy}>
             Logout
           </button>
@@ -326,6 +383,86 @@ function App() {
           </button>
         </section>
       </main>
+
+      <section className="panel panel--main" style={{ marginTop: 24 }}>
+        <div className="panel-head">
+          <h2 style={{ fontFamily: "var(--serif)", fontSize: "clamp(24px, 4vw, 36px)", lineHeight: 1 }}>
+            Benchmark
+          </h2>
+          <p>
+            Run a round-robin benchmark where every model plays against every
+            other model.{" "}
+            <a href="/bench" style={{ color: "var(--accent)", textDecoration: "none" }}>
+              View results
+            </a>
+          </p>
+        </div>
+
+        {snapshot?.bench ? (
+          <div>
+            <div className="status-grid" style={{ marginBottom: 16 }}>
+              <StatusCard label="Status" value={snapshot.bench.status} />
+              <StatusCard
+                label="Progress"
+                value={`${snapshot.bench.completedRounds}/${snapshot.bench.totalRounds}`}
+              />
+            </div>
+            <div className="actions" style={{ gridTemplateColumns: "repeat(2, minmax(0, 1fr))" }}>
+              <button
+                type="button"
+                className="btn btn--danger"
+                disabled={busy}
+                onClick={onBenchCancel}
+              >
+                {pending === "bench-cancel" ? "Cancelling..." : "Cancel Benchmark"}
+              </button>
+              <a
+                href="/bench"
+                className="btn"
+                style={{ textAlign: "center", textDecoration: "none", display: "inline-flex", alignItems: "center", justifyContent: "center" }}
+              >
+                View Live Results
+              </a>
+            </div>
+          </div>
+        ) : (
+          <div className="actions" style={{ gridTemplateColumns: "auto 1fr auto" }}>
+            <select
+              value={benchRoundsPerPairing}
+              onChange={(e) => setBenchRoundsPerPairing(Number(e.target.value))}
+              style={{
+                background: "var(--bg)",
+                border: "1px solid var(--border)",
+                color: "var(--text)",
+                fontFamily: "var(--mono)",
+                fontSize: 12,
+                padding: "10px 12px",
+                outline: "none",
+              }}
+              disabled={busy}
+            >
+              <option value={1}>1 round/pairing</option>
+              <option value={3}>3 rounds/pairing</option>
+              <option value={5}>5 rounds/pairing</option>
+            </select>
+            <button
+              type="button"
+              className="btn btn--primary"
+              disabled={busy}
+              onClick={onBenchStart}
+            >
+              {pending === "bench-start" ? "Starting..." : "Start Benchmark"}
+            </button>
+            <a
+              href="/bench"
+              className="btn"
+              style={{ textAlign: "center", textDecoration: "none", display: "inline-flex", alignItems: "center", justifyContent: "center" }}
+            >
+              Past Results
+            </a>
+          </div>
+        )}
+      </section>
 
       {isResetOpen && (
         <div className="modal-backdrop" role="dialog" aria-modal="true">

--- a/bench-db.ts
+++ b/bench-db.ts
@@ -1,0 +1,144 @@
+import { db } from "./db.ts";
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS bench_runs (
+    id TEXT PRIMARY KEY,
+    status TEXT NOT NULL DEFAULT 'running',
+    config TEXT NOT NULL,
+    started_at INTEGER NOT NULL,
+    finished_at INTEGER,
+    total_rounds INTEGER NOT NULL,
+    completed_rounds INTEGER NOT NULL DEFAULT 0,
+    error TEXT
+  );
+`);
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS bench_rounds (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    pairing_index INTEGER NOT NULL,
+    round_num INTEGER NOT NULL,
+    data TEXT NOT NULL,
+    FOREIGN KEY (run_id) REFERENCES bench_runs(id)
+  );
+`);
+
+export type BenchRunRow = {
+  id: string;
+  status: string;
+  config: string;
+  started_at: number;
+  finished_at: number | null;
+  total_rounds: number;
+  completed_rounds: number;
+  error: string | null;
+};
+
+export type BenchRoundRow = {
+  id: number;
+  run_id: string;
+  pairing_index: number;
+  round_num: number;
+  data: string;
+};
+
+export function saveBenchRun(run: {
+  id: string;
+  status: string;
+  config: object;
+  startedAt: number;
+  totalRounds: number;
+}) {
+  db.prepare(
+    `INSERT INTO bench_runs (id, status, config, started_at, total_rounds, completed_rounds)
+     VALUES ($id, $status, $config, $started_at, $total_rounds, 0)`,
+  ).run({
+    $id: run.id,
+    $status: run.status,
+    $config: JSON.stringify(run.config),
+    $started_at: run.startedAt,
+    $total_rounds: run.totalRounds,
+  });
+}
+
+export function updateBenchRunStatus(
+  id: string,
+  update: {
+    status?: string;
+    completedRounds?: number;
+    finishedAt?: number;
+    error?: string;
+  },
+) {
+  const sets: string[] = [];
+  const params: Record<string, unknown> = { $id: id };
+
+  if (update.status !== undefined) {
+    sets.push("status = $status");
+    params.$status = update.status;
+  }
+  if (update.completedRounds !== undefined) {
+    sets.push("completed_rounds = $completed_rounds");
+    params.$completed_rounds = update.completedRounds;
+  }
+  if (update.finishedAt !== undefined) {
+    sets.push("finished_at = $finished_at");
+    params.$finished_at = update.finishedAt;
+  }
+  if (update.error !== undefined) {
+    sets.push("error = $error");
+    params.$error = update.error;
+  }
+
+  if (sets.length === 0) return;
+  db.prepare(`UPDATE bench_runs SET ${sets.join(", ")} WHERE id = $id`).run(
+    params,
+  );
+}
+
+export function saveBenchRound(round: {
+  runId: string;
+  pairingIndex: number;
+  roundNum: number;
+  data: object;
+}) {
+  db.prepare(
+    `INSERT INTO bench_rounds (run_id, pairing_index, round_num, data)
+     VALUES ($run_id, $pairing_index, $round_num, $data)`,
+  ).run({
+    $run_id: round.runId,
+    $pairing_index: round.pairingIndex,
+    $round_num: round.roundNum,
+    $data: JSON.stringify(round.data),
+  });
+}
+
+export function getBenchRuns(): BenchRunRow[] {
+  return db
+    .query("SELECT * FROM bench_runs ORDER BY started_at DESC")
+    .all() as BenchRunRow[];
+}
+
+export function getBenchRun(id: string): BenchRunRow | null {
+  return (
+    (db
+      .query("SELECT * FROM bench_runs WHERE id = $id")
+      .get({ $id: id }) as BenchRunRow | null) ?? null
+  );
+}
+
+export function getBenchRounds(runId: string): BenchRoundRow[] {
+  return db
+    .query(
+      "SELECT * FROM bench_rounds WHERE run_id = $run_id ORDER BY pairing_index ASC, round_num ASC",
+    )
+    .all({ $run_id: runId }) as BenchRoundRow[];
+}
+
+export function markStaleBenchRunsAsError() {
+  db.prepare(
+    `UPDATE bench_runs SET status = 'error', error = 'Server restarted', finished_at = $now
+     WHERE status = 'running'`,
+  ).run({ $now: Date.now() });
+}

--- a/bench-frontend.tsx
+++ b/bench-frontend.tsx
@@ -530,10 +530,12 @@ function App() {
     let ws: WebSocket;
     let reconnectTimer: ReturnType<typeof setTimeout>;
 
+    let unmounted = false;
+
     function connect() {
       ws = new WebSocket(wsUrl);
       ws.onclose = () => {
-        reconnectTimer = setTimeout(connect, 3000);
+        if (!unmounted) reconnectTimer = setTimeout(connect, 3000);
       };
       ws.onmessage = (e) => {
         try {
@@ -551,9 +553,16 @@ function App() {
                 .then((r) => r.json())
                 .then((data: BenchRun[]) => {
                   setRuns(data);
-                  // Auto-select the latest completed run
                   if (data.length > 0) {
-                    setSelectedRunId(data[0]!.id);
+                    const latestId = data[0]!.id;
+                    setSelectedRunId(latestId);
+                    // Force re-fetch results even if selectedRunId didn't change
+                    fetch(`/api/bench/results/${latestId}`)
+                      .then((r) => r.json())
+                      .then((resData: { run: BenchRun; rounds: BenchRound[] }) => {
+                        setRoundsData(resData.rounds.map((r) => JSON.parse(r.data) as BenchRoundData));
+                      })
+                      .catch(() => {});
                   }
                 })
                 .catch(() => {});
@@ -565,6 +574,7 @@ function App() {
 
     connect();
     return () => {
+      unmounted = true;
       clearTimeout(reconnectTimer);
       ws?.close();
     };

--- a/bench-frontend.tsx
+++ b/bench-frontend.tsx
@@ -1,0 +1,727 @@
+import React, { useState, useEffect, useMemo } from "react";
+import { createRoot } from "react-dom/client";
+import "./bench.css";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type Model = { id: string; name: string };
+
+type BenchRun = {
+  id: string;
+  status: string;
+  config: string;
+  started_at: number;
+  finished_at: number | null;
+  total_rounds: number;
+  completed_rounds: number;
+  error: string | null;
+};
+
+type BenchRoundData = {
+  pairingIndex: number;
+  roundNum: number;
+  prompter: Model;
+  prompt: string;
+  modelA: Model;
+  answerA: string;
+  modelB: Model;
+  answerB: string;
+  votes: { voter: Model; votedFor: "A" | "B" | null }[];
+  votesA: number;
+  votesB: number;
+  winner: "A" | "B" | "tie";
+  error?: string;
+};
+
+type BenchRound = {
+  id: number;
+  run_id: string;
+  pairing_index: number;
+  round_num: number;
+  data: string;
+};
+
+type ActiveBenchState = {
+  id: string;
+  status: string;
+  totalRounds: number;
+  completedRounds: number;
+  currentPairing?: { modelA: Model; modelB: Model };
+  currentRound?: number;
+} | null;
+
+// ── Model colors & logos ─────────────────────────────────────────────────────
+
+const MODEL_COLORS: Record<string, string> = {
+  "Gemini 3.1 Pro": "#4285F4",
+  "Kimi K2": "#00E599",
+  "DeepSeek 3.2": "#4D6BFE",
+  "GLM-5": "#1F63EC",
+  "GPT-5.2": "#10A37F",
+  "Opus 4.6": "#D97757",
+  "Sonnet 4.6": "#D97757",
+  "Grok 4.1": "#FFFFFF",
+  "MiniMax 2.5": "#FF3B30",
+};
+
+function getColor(name: string): string {
+  return MODEL_COLORS[name] ?? "#A1A1A1";
+}
+
+function getLogo(name: string): string | null {
+  if (name.includes("Gemini")) return "/assets/logos/gemini.svg";
+  if (name.includes("Kimi")) return "/assets/logos/kimi.svg";
+  if (name.includes("DeepSeek")) return "/assets/logos/deepseek.svg";
+  if (name.includes("GLM")) return "/assets/logos/glm.svg";
+  if (name.includes("GPT")) return "/assets/logos/openai.svg";
+  if (name.includes("Opus") || name.includes("Sonnet"))
+    return "/assets/logos/claude.svg";
+  if (name.includes("Grok")) return "/assets/logos/grok.svg";
+  if (name.includes("MiniMax")) return "/assets/logos/minimax.svg";
+  return null;
+}
+
+function ModelTag({ model, small }: { model: Model; small?: boolean }) {
+  const logo = getLogo(model.name);
+  const color = getColor(model.name);
+  return (
+    <span
+      className={`model-tag ${small ? "model-tag--sm" : ""}`}
+      style={{ color }}
+    >
+      {logo && <img src={logo} alt="" className="model-tag__logo" />}
+      {model.name}
+    </span>
+  );
+}
+
+// ── Rankings computation ─────────────────────────────────────────────────────
+
+type ModelStats = {
+  name: string;
+  wins: number;
+  losses: number;
+  ties: number;
+  totalVotesFor: number;
+  totalVotesCast: number;
+};
+
+function computeRankings(rounds: BenchRoundData[]): ModelStats[] {
+  const stats: Record<string, ModelStats> = {};
+
+  function ensure(name: string) {
+    if (!stats[name]) {
+      stats[name] = {
+        name,
+        wins: 0,
+        losses: 0,
+        ties: 0,
+        totalVotesFor: 0,
+        totalVotesCast: 0,
+      };
+    }
+  }
+
+  for (const r of rounds) {
+    if (r.error) continue;
+    ensure(r.modelA.name);
+    ensure(r.modelB.name);
+
+    const totalVotes = r.votesA + r.votesB;
+    stats[r.modelA.name]!.totalVotesFor += r.votesA;
+    stats[r.modelA.name]!.totalVotesCast += totalVotes;
+    stats[r.modelB.name]!.totalVotesFor += r.votesB;
+    stats[r.modelB.name]!.totalVotesCast += totalVotes;
+
+    if (r.winner === "A") {
+      stats[r.modelA.name]!.wins++;
+      stats[r.modelB.name]!.losses++;
+    } else if (r.winner === "B") {
+      stats[r.modelB.name]!.wins++;
+      stats[r.modelA.name]!.losses++;
+    } else {
+      stats[r.modelA.name]!.ties++;
+      stats[r.modelB.name]!.ties++;
+    }
+  }
+
+  return Object.values(stats).sort((a, b) => {
+    const aWinPct =
+      a.wins + a.losses + a.ties > 0
+        ? a.wins / (a.wins + a.losses + a.ties)
+        : 0;
+    const bWinPct =
+      b.wins + b.losses + b.ties > 0
+        ? b.wins / (b.wins + b.losses + b.ties)
+        : 0;
+    if (bWinPct !== aWinPct) return bWinPct - aWinPct;
+    return b.wins - a.wins;
+  });
+}
+
+// ── Head-to-head computation ─────────────────────────────────────────────────
+
+type H2HRecord = {
+  wins: number;
+  losses: number;
+  ties: number;
+  rounds: BenchRoundData[];
+};
+
+function computeH2H(
+  rounds: BenchRoundData[],
+): Record<string, Record<string, H2HRecord>> {
+  const h2h: Record<string, Record<string, H2HRecord>> = {};
+
+  function ensure(a: string, b: string) {
+    if (!h2h[a]) h2h[a] = {};
+    if (!h2h[a][b])
+      h2h[a][b] = { wins: 0, losses: 0, ties: 0, rounds: [] };
+  }
+
+  for (const r of rounds) {
+    if (r.error) continue;
+    const a = r.modelA.name;
+    const b = r.modelB.name;
+    ensure(a, b);
+    ensure(b, a);
+
+    h2h[a]![b]!.rounds.push(r);
+    h2h[b]![a]!.rounds.push(r);
+
+    if (r.winner === "A") {
+      h2h[a]![b]!.wins++;
+      h2h[b]![a]!.losses++;
+    } else if (r.winner === "B") {
+      h2h[b]![a]!.wins++;
+      h2h[a]![b]!.losses++;
+    } else {
+      h2h[a]![b]!.ties++;
+      h2h[b]![a]!.ties++;
+    }
+  }
+
+  return h2h;
+}
+
+// ── Components ───────────────────────────────────────────────────────────────
+
+function BenchProgress({
+  active,
+  onCancel,
+}: {
+  active: ActiveBenchState;
+  onCancel: () => void;
+}) {
+  if (!active || active.status !== "running") return null;
+
+  const pct =
+    active.totalRounds > 0
+      ? Math.round((active.completedRounds / active.totalRounds) * 100)
+      : 0;
+
+  return (
+    <div className="bench-progress">
+      <div className="progress-info">
+        <span className="progress-label">
+          Benchmark running: <strong>{active.completedRounds}</strong> /{" "}
+          {active.totalRounds} rounds
+        </span>
+        {active.currentPairing && (
+          <span className="progress-current">
+            <ModelTag model={active.currentPairing.modelA} small />
+            {" vs "}
+            <ModelTag model={active.currentPairing.modelB} small />
+            {active.currentRound && ` (rep ${active.currentRound})`}
+          </span>
+        )}
+      </div>
+      <div className="progress-bar">
+        <div className="progress-bar__fill" style={{ width: `${pct}%` }} />
+      </div>
+      <div className="progress-actions">
+        <button className="btn btn--danger btn--sm" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function OverallRankings({ rounds }: { rounds: BenchRoundData[] }) {
+  const rankings = useMemo(() => computeRankings(rounds), [rounds]);
+
+  if (rankings.length === 0) return null;
+
+  return (
+    <div className="rankings">
+      <h2>Overall Rankings</h2>
+      <table className="rankings-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Model</th>
+            <th className="num">W</th>
+            <th className="num">L</th>
+            <th className="num">T</th>
+            <th className="num">Win%</th>
+            <th className="num">Vote Share</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rankings.map((s, i) => {
+            const total = s.wins + s.losses + s.ties;
+            const winPct = total > 0 ? ((s.wins / total) * 100).toFixed(1) : "0.0";
+            const voteShare =
+              s.totalVotesCast > 0
+                ? ((s.totalVotesFor / s.totalVotesCast) * 100).toFixed(1)
+                : "0.0";
+            return (
+              <tr key={s.name}>
+                <td className="rank-num">
+                  {i === 0 && s.wins > 0 ? (
+                    <span className="rank-crown">👑</span>
+                  ) : (
+                    i + 1
+                  )}
+                </td>
+                <td>
+                  <ModelTag
+                    model={{ id: s.name, name: s.name }}
+                    small
+                  />
+                </td>
+                <td className="num">{s.wins}</td>
+                <td className="num">{s.losses}</td>
+                <td className="num">{s.ties}</td>
+                <td className="num win-pct" style={{ color: getColor(s.name) }}>
+                  {winPct}%
+                </td>
+                <td className="num">{voteShare}%</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function HeadToHeadMatrix({
+  rounds,
+  onSelectPairing,
+}: {
+  rounds: BenchRoundData[];
+  onSelectPairing: (a: string, b: string) => void;
+}) {
+  const rankings = useMemo(() => computeRankings(rounds), [rounds]);
+  const h2h = useMemo(() => computeH2H(rounds), [rounds]);
+  const models = rankings.map((r) => r.name);
+
+  if (models.length === 0) return null;
+
+  return (
+    <div className="matrix">
+      <h2>Head-to-Head</h2>
+      <div className="matrix-scroll">
+        <table className="matrix-grid">
+          <thead>
+            <tr>
+              <th className="row-header" />
+              {models.map((m) => (
+                <th key={m}>
+                  <ModelTag model={{ id: m, name: m }} small />
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {models.map((row) => (
+              <tr key={row}>
+                <th className="row-header">
+                  <ModelTag model={{ id: row, name: row }} small />
+                </th>
+                {models.map((col) => {
+                  if (row === col) {
+                    return (
+                      <td key={col} className="matrix-self">
+                        -
+                      </td>
+                    );
+                  }
+                  const record = h2h[row]?.[col];
+                  if (!record) {
+                    return (
+                      <td key={col} className="matrix-tie">
+                        -
+                      </td>
+                    );
+                  }
+                  const cls =
+                    record.wins > record.losses
+                      ? "matrix-win"
+                      : record.losses > record.wins
+                        ? "matrix-loss"
+                        : "matrix-tie";
+                  return (
+                    <td
+                      key={col}
+                      className={cls}
+                      onClick={() => onSelectPairing(row, col)}
+                      title={`${row} vs ${col}: ${record.wins}W-${record.losses}L-${record.ties}T`}
+                    >
+                      {record.wins}-{record.losses}
+                      {record.ties > 0 ? `-${record.ties}` : ""}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function MatchupDetail({
+  modelA,
+  modelB,
+  rounds,
+  onClose,
+}: {
+  modelA: string;
+  modelB: string;
+  rounds: BenchRoundData[];
+  onClose: () => void;
+}) {
+  const matchRounds = rounds.filter(
+    (r) =>
+      !r.error &&
+      ((r.modelA.name === modelA && r.modelB.name === modelB) ||
+        (r.modelA.name === modelB && r.modelB.name === modelA)),
+  );
+
+  return (
+    <div className="matchup-detail">
+      <div className="matchup-detail__header">
+        <div className="matchup-detail__title">
+          <ModelTag model={{ id: modelA, name: modelA }} small />
+          {" vs "}
+          <ModelTag model={{ id: modelB, name: modelB }} small />
+        </div>
+        <button className="matchup-detail__close" onClick={onClose}>
+          Close
+        </button>
+      </div>
+      {matchRounds.length === 0 ? (
+        <div className="empty-state">No rounds played</div>
+      ) : (
+        matchRounds.map((r, i) => {
+          const isAModelA = r.modelA.name === modelA;
+          const leftModel = isAModelA ? r.modelA : r.modelB;
+          const rightModel = isAModelA ? r.modelB : r.modelA;
+          const leftAnswer = isAModelA ? r.answerA : r.answerB;
+          const rightAnswer = isAModelA ? r.answerB : r.answerA;
+          const leftVotes = isAModelA ? r.votesA : r.votesB;
+          const rightVotes = isAModelA ? r.votesB : r.votesA;
+          const leftWon = leftVotes > rightVotes;
+          const rightWon = rightVotes > leftVotes;
+
+          return (
+            <div key={i} className="matchup-round">
+              <div className="matchup-round__label">
+                Round {i + 1} — prompted by{" "}
+                <ModelTag model={r.prompter} small />
+              </div>
+              <div className="matchup-round__prompt">{r.prompt}</div>
+              <div className="matchup-answers">
+                <div
+                  className={`matchup-answer ${leftWon ? "matchup-answer--winner" : ""}`}
+                >
+                  <div className="matchup-answer__model">
+                    <ModelTag model={leftModel} small />
+                    {leftWon && " WIN"}
+                  </div>
+                  <div className="matchup-answer__text">
+                    &ldquo;{leftAnswer}&rdquo;
+                  </div>
+                  <div className="matchup-answer__votes">
+                    {leftVotes} vote{leftVotes !== 1 ? "s" : ""}
+                  </div>
+                </div>
+                <div
+                  className={`matchup-answer ${rightWon ? "matchup-answer--winner" : ""}`}
+                >
+                  <div className="matchup-answer__model">
+                    <ModelTag model={rightModel} small />
+                    {rightWon && " WIN"}
+                  </div>
+                  <div className="matchup-answer__text">
+                    &ldquo;{rightAnswer}&rdquo;
+                  </div>
+                  <div className="matchup-answer__votes">
+                    {rightVotes} vote{rightVotes !== 1 ? "s" : ""}
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+// ── App ──────────────────────────────────────────────────────────────────────
+
+function App() {
+  const [runs, setRuns] = useState<BenchRun[]>([]);
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+  const [roundsData, setRoundsData] = useState<BenchRoundData[]>([]);
+  const [activeBench, setActiveBench] = useState<ActiveBenchState>(null);
+  const [selectedPairing, setSelectedPairing] = useState<{
+    a: string;
+    b: string;
+  } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch runs list
+  useEffect(() => {
+    fetch("/api/bench/runs")
+      .then((r) => r.json())
+      .then((data: BenchRun[]) => {
+        setRuns(data);
+        if (data.length > 0 && !selectedRunId) {
+          setSelectedRunId(data[0]!.id);
+        }
+        setLoading(false);
+      })
+      .catch(() => {
+        setError("Failed to load benchmark runs");
+        setLoading(false);
+      });
+  }, []);
+
+  // Fetch selected run results
+  useEffect(() => {
+    if (!selectedRunId) {
+      setRoundsData([]);
+      return;
+    }
+    fetch(`/api/bench/results/${selectedRunId}`)
+      .then((r) => r.json())
+      .then(
+        (data: { run: BenchRun; rounds: BenchRound[] }) => {
+          const parsed = data.rounds.map(
+            (r) => JSON.parse(r.data) as BenchRoundData,
+          );
+          setRoundsData(parsed);
+        },
+      )
+      .catch(() => setError("Failed to load run results"));
+  }, [selectedRunId]);
+
+  // WebSocket for real-time progress
+  useEffect(() => {
+    const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const wsUrl = `${wsProtocol}//${window.location.host}/ws`;
+    let ws: WebSocket;
+    let reconnectTimer: ReturnType<typeof setTimeout>;
+
+    function connect() {
+      ws = new WebSocket(wsUrl);
+      ws.onclose = () => {
+        reconnectTimer = setTimeout(connect, 3000);
+      };
+      ws.onmessage = (e) => {
+        try {
+          const msg = JSON.parse(e.data);
+          if (msg.bench !== undefined) {
+            setActiveBench(msg.bench);
+
+            // Refresh runs list when bench status changes
+            if (
+              msg.bench === null ||
+              msg.bench.status === "completed" ||
+              msg.bench.status === "cancelled"
+            ) {
+              fetch("/api/bench/runs")
+                .then((r) => r.json())
+                .then((data: BenchRun[]) => {
+                  setRuns(data);
+                  // Auto-select the latest completed run
+                  if (data.length > 0) {
+                    setSelectedRunId(data[0]!.id);
+                  }
+                })
+                .catch(() => {});
+            }
+          }
+        } catch {}
+      };
+    }
+
+    connect();
+    return () => {
+      clearTimeout(reconnectTimer);
+      ws?.close();
+    };
+  }, []);
+
+  // Also fetch active status on mount
+  useEffect(() => {
+    fetch("/api/bench/status")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.active) setActiveBench(data.active);
+      })
+      .catch(() => {});
+  }, []);
+
+  async function handleCancel() {
+    try {
+      await fetch("/api/bench/cancel", { method: "POST" });
+    } catch {
+      setError("Failed to cancel benchmark");
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="bench">
+        <div className="loading">Loading benchmark data...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bench">
+      <header className="bench-header">
+        <a href="/" className="logo-link">
+          quipslop
+        </a>
+        <nav className="quick-links">
+          <a href="/">Live Game</a>
+          <a href="/history">History</a>
+          <a href="/admin">Admin</a>
+        </nav>
+      </header>
+
+      <div className="panel">
+        <div className="panel-head">
+          <h1>Benchmark</h1>
+          <p>
+            Round-robin benchmark: every model plays against every other model.
+            Results show overall rankings and head-to-head records.
+          </p>
+        </div>
+
+        {error && <div className="error-banner">{error}</div>}
+
+        <BenchProgress active={activeBench} onCancel={handleCancel} />
+
+        {runs.length > 0 && (
+          <div className="run-selector">
+            <label>Run:</label>
+            <select
+              value={selectedRunId ?? ""}
+              onChange={(e) => {
+                setSelectedRunId(e.target.value);
+                setSelectedPairing(null);
+              }}
+            >
+              {runs.map((run) => (
+                <option key={run.id} value={run.id}>
+                  {new Date(run.started_at).toLocaleDateString()} —{" "}
+                  {run.completed_rounds}/{run.total_rounds} rounds (
+                  {run.status})
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      {roundsData.length > 0 ? (
+        <>
+          <OverallRankings rounds={roundsData} />
+
+          {selectedPairing && (
+            <MatchupDetail
+              modelA={selectedPairing.a}
+              modelB={selectedPairing.b}
+              rounds={roundsData}
+              onClose={() => setSelectedPairing(null)}
+            />
+          )}
+
+          <HeadToHeadMatrix
+            rounds={roundsData}
+            onSelectPairing={(a, b) => setSelectedPairing({ a, b })}
+          />
+        </>
+      ) : selectedRunId ? (
+        <div className="empty-state">
+          {activeBench?.id === selectedRunId
+            ? "Benchmark in progress, results will appear as rounds complete..."
+            : "No round data for this run"}
+        </div>
+      ) : (
+        <div className="empty-state">
+          No benchmark runs yet. Start one from the Admin panel.
+        </div>
+      )}
+
+      {runs.length > 1 && (
+        <div className="panel">
+          <h2
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: 13,
+              fontWeight: 700,
+              textTransform: "uppercase" as const,
+              letterSpacing: 1,
+              color: "var(--text-dim)",
+              marginBottom: 16,
+            }}
+          >
+            All Runs
+          </h2>
+          <div className="run-list">
+            {runs.map((run) => (
+              <div
+                key={run.id}
+                className={`run-item ${selectedRunId === run.id ? "run-item--active" : ""}`}
+                onClick={() => {
+                  setSelectedRunId(run.id);
+                  setSelectedPairing(null);
+                }}
+              >
+                <span className={`run-item__status run-item__status--${run.status}`}>
+                  {run.status}
+                </span>
+                <div className="run-item__info">
+                  <span className="run-item__date">
+                    {new Date(run.started_at).toLocaleString()}
+                  </span>
+                  <span className="run-item__stats">
+                    {run.completed_rounds}/{run.total_rounds} rounds
+                    {run.finished_at &&
+                      ` — ${((run.finished_at - run.started_at) / 1000).toFixed(0)}s`}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Mount ────────────────────────────────────────────────────────────────────
+
+const root = createRoot(document.getElementById("root")!);
+root.render(<App />);

--- a/bench.css
+++ b/bench.css
@@ -1,0 +1,687 @@
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --bg: #0a0a0a;
+  --surface: #111;
+  --border: #1c1c1c;
+  --text: #ededed;
+  --text-dim: #888;
+  --text-muted: #444;
+  --accent: #D97757;
+  --serif: 'DM Serif Display', Georgia, serif;
+  --sans: 'Inter', -apple-system, sans-serif;
+  --mono: 'JetBrains Mono', 'SF Mono', monospace;
+  --danger: #ef4444;
+  --green: #22c55e;
+  --red: #ef4444;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+/* ── Layout ──────────────────────────────────────────────────── */
+
+.bench {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+}
+
+.bench-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 28px;
+  gap: 16px;
+}
+
+.logo-link {
+  display: inline-flex;
+  text-decoration: none;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.logo-link img {
+  height: 20px;
+  width: auto;
+}
+
+.quick-links {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.quick-links a {
+  color: var(--text-dim);
+  text-decoration: none;
+  font-size: 12px;
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+}
+
+.quick-links a:hover {
+  color: var(--text);
+}
+
+/* ── Panel ───────────────────────────────────────────────────── */
+
+.panel {
+  width: 100%;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 28px;
+  margin-bottom: 24px;
+}
+
+.panel-head {
+  margin-bottom: 24px;
+}
+
+.panel-head h1 {
+  font-family: var(--serif);
+  font-size: clamp(28px, 5vw, 42px);
+  line-height: 1;
+  letter-spacing: -0.8px;
+}
+
+.panel-head p {
+  color: var(--text-dim);
+  margin-top: 8px;
+}
+
+/* ── Model Tag ───────────────────────────────────────────────── */
+
+.model-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+.model-tag--sm {
+  font-size: 12px;
+  gap: 4px;
+}
+
+.model-tag__logo {
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
+}
+
+.model-tag--sm .model-tag__logo {
+  width: 14px;
+  height: 14px;
+}
+
+/* ── Progress ────────────────────────────────────────────────── */
+
+.bench-progress {
+  margin-bottom: 24px;
+}
+
+.progress-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.progress-label {
+  font-family: var(--mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--text-dim);
+}
+
+.progress-label strong {
+  color: var(--text);
+}
+
+.progress-current {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.progress-bar {
+  height: 4px;
+  background: var(--border);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+
+.progress-bar__fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  transition: width 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.progress-actions {
+  display: flex;
+  gap: 10px;
+}
+
+/* ── Buttons ─────────────────────────────────────────────────── */
+
+.btn {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: transform 0.15s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: #3a3a3a;
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--bg);
+  font-weight: 700;
+}
+
+.btn--danger {
+  background: transparent;
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.btn--sm {
+  padding: 6px 12px;
+  font-size: 11px;
+}
+
+/* ── Run selector ────────────────────────────────────────────── */
+
+.run-selector {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+
+.run-selector label {
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--text-muted);
+}
+
+.run-selector select {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
+  padding: 6px 10px;
+  outline: none;
+}
+
+.run-selector select:focus {
+  border-color: var(--accent);
+}
+
+/* ── Rankings table ──────────────────────────────────────────── */
+
+.rankings {
+  margin-bottom: 32px;
+}
+
+.rankings h2 {
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-dim);
+  margin-bottom: 16px;
+}
+
+.rankings-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.rankings-table th {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.rankings-table th.num {
+  text-align: right;
+}
+
+.rankings-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.rankings-table td.num {
+  text-align: right;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.rankings-table tr:last-child td {
+  border-bottom: none;
+}
+
+.rank-num {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text-muted);
+  width: 32px;
+}
+
+.rank-crown {
+  font-size: 14px;
+}
+
+.win-pct {
+  font-weight: 700;
+}
+
+/* ── Head-to-head matrix ─────────────────────────────────────── */
+
+.matrix {
+  margin-bottom: 32px;
+}
+
+.matrix h2 {
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-dim);
+  margin-bottom: 16px;
+}
+
+.matrix-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.matrix-grid {
+  border-collapse: collapse;
+  min-width: 100%;
+}
+
+.matrix-grid th {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  padding: 8px 10px;
+  white-space: nowrap;
+  position: sticky;
+  top: 0;
+  background: var(--surface);
+  z-index: 1;
+}
+
+.matrix-grid th.row-header {
+  text-align: left;
+  position: sticky;
+  left: 0;
+  background: var(--surface);
+  z-index: 2;
+}
+
+.matrix-grid td {
+  padding: 8px 10px;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 12px;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.15s;
+  white-space: nowrap;
+  min-width: 80px;
+}
+
+.matrix-grid td:hover:not(.matrix-self) {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.matrix-self {
+  background: var(--border);
+  color: var(--text-muted);
+  cursor: default;
+}
+
+.matrix-win {
+  color: var(--green);
+}
+
+.matrix-loss {
+  color: var(--red);
+}
+
+.matrix-tie {
+  color: var(--text-muted);
+}
+
+/* ── Matchup detail ──────────────────────────────────────────── */
+
+.matchup-detail {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  padding: 20px;
+  margin-bottom: 24px;
+  animation: slide-in 0.2s ease-out;
+}
+
+@keyframes slide-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.matchup-detail__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  gap: 12px;
+}
+
+.matchup-detail__title {
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.matchup-detail__close {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-size: 11px;
+  padding: 4px 10px;
+  cursor: pointer;
+  border-radius: 999px;
+}
+
+.matchup-detail__close:hover {
+  color: var(--text);
+  border-color: var(--text-muted);
+}
+
+.matchup-round {
+  border: 1px solid var(--border);
+  padding: 16px;
+  margin-bottom: 12px;
+}
+
+.matchup-round:last-child {
+  margin-bottom: 0;
+}
+
+.matchup-round__label {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+
+.matchup-round__prompt {
+  font-family: var(--serif);
+  font-size: 18px;
+  color: var(--text);
+  border-left: 3px solid var(--accent);
+  padding-left: 14px;
+  margin-bottom: 14px;
+}
+
+.matchup-answers {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.matchup-answer {
+  padding: 12px;
+  border: 1px solid var(--border);
+}
+
+.matchup-answer--winner {
+  border-color: var(--green);
+  background: rgba(34, 197, 94, 0.05);
+}
+
+.matchup-answer__model {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.matchup-answer__text {
+  font-family: var(--serif);
+  font-size: 16px;
+  color: var(--text-dim);
+}
+
+.matchup-answer--winner .matchup-answer__text {
+  color: var(--text);
+}
+
+.matchup-answer__votes {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 8px;
+}
+
+/* ── Run list ────────────────────────────────────────────────── */
+
+.run-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.run-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.run-item:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.run-item--active {
+  border-color: var(--accent);
+  background: rgba(217, 119, 87, 0.05);
+}
+
+.run-item__status {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  padding: 3px 8px;
+  border-radius: 3px;
+}
+
+.run-item__status--running {
+  background: rgba(34, 197, 94, 0.15);
+  color: var(--green);
+}
+
+.run-item__status--completed {
+  background: rgba(34, 197, 94, 0.1);
+  color: var(--green);
+}
+
+.run-item__status--cancelled {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-muted);
+}
+
+.run-item__status--error {
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--red);
+}
+
+.run-item__info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.run-item__date {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.run-item__stats {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* ── Empty state ─────────────────────────────────────────────── */
+
+.empty-state {
+  text-align: center;
+  padding: 48px 24px;
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+/* ── Error banner ────────────────────────────────────────────── */
+
+.error-banner {
+  border: 1px solid var(--danger);
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--danger);
+  padding: 10px 12px;
+  font-size: 14px;
+  font-family: var(--mono);
+  margin-bottom: 16px;
+}
+
+/* ── Loading ─────────────────────────────────────────────────── */
+
+.loading {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  padding: 14px 18px;
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-dim);
+  text-align: center;
+}
+
+/* ── Responsive ──────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .bench {
+    padding: 18px 14px 26px;
+  }
+
+  .panel {
+    padding: 20px;
+  }
+
+  .matchup-answers {
+    grid-template-columns: 1fr;
+  }
+
+  .bench-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 560px) {
+  .run-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }

--- a/bench.html
+++ b/bench.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>quipslop Benchmark</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter:wght@400;500;600;700;900&family=JetBrains+Mono:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./bench.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./bench-frontend.tsx"></script>
+  </body>
+</html>

--- a/bench.ts
+++ b/bench.ts
@@ -1,0 +1,339 @@
+import {
+  MODELS,
+  type Model,
+  shuffle,
+  withRetry,
+  callGeneratePrompt,
+  callGenerateAnswer,
+  callVote,
+  isRealString,
+  log,
+} from "./game.ts";
+import {
+  saveBenchRun,
+  updateBenchRunStatus,
+  saveBenchRound,
+} from "./bench-db.ts";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type BenchPairing = {
+  index: number;
+  modelA: Model;
+  modelB: Model;
+};
+
+export type BenchRoundResult = {
+  pairingIndex: number;
+  roundNum: number;
+  prompter: Model;
+  prompt: string;
+  modelA: Model;
+  answerA: string;
+  modelB: Model;
+  answerB: string;
+  votes: { voter: Model; votedFor: "A" | "B" | null }[];
+  votesA: number;
+  votesB: number;
+  winner: "A" | "B" | "tie";
+  error?: string;
+};
+
+export type BenchRunConfig = {
+  models: Model[];
+  roundsPerPairing: number;
+};
+
+export type BenchRunState = {
+  id: string;
+  status: "running" | "completed" | "cancelled" | "error";
+  config: BenchRunConfig;
+  startedAt: number;
+  finishedAt?: number;
+  totalRounds: number;
+  completedRounds: number;
+  currentPairing?: BenchPairing;
+  currentRound?: number;
+  error?: string;
+};
+
+// ── State ──────────────────────────────────────────────────────────────────
+
+let activeBenchRun: BenchRunState | null = null;
+let cancelFlag = false;
+
+export function getActiveBenchRun(): BenchRunState | null {
+  return activeBenchRun;
+}
+
+export function cancelBench(): boolean {
+  if (!activeBenchRun) return false;
+  cancelFlag = true;
+  return true;
+}
+
+// ── Pairing generation ─────────────────────────────────────────────────────
+
+export function generatePairings(models: readonly Model[]): BenchPairing[] {
+  const pairings: BenchPairing[] = [];
+  let index = 0;
+  for (let i = 0; i < models.length; i++) {
+    for (let j = i + 1; j < models.length; j++) {
+      pairings.push({ index, modelA: models[i], modelB: models[j] });
+      index++;
+    }
+  }
+  return shuffle(pairings);
+}
+
+// ── Single round ───────────────────────────────────────────────────────────
+
+async function runBenchRound(
+  pairing: BenchPairing,
+  roundNum: number,
+  allModels: readonly Model[],
+): Promise<BenchRoundResult> {
+  const nonContestants = allModels.filter(
+    (m) => m.id !== pairing.modelA.id && m.id !== pairing.modelB.id,
+  );
+  const shuffledNon = shuffle([...nonContestants]);
+  const prompter = shuffledNon[0]!;
+  const voters = shuffledNon; // all non-contestants vote (including prompter)
+
+  const label = `Bench:P${pairing.index}R${roundNum}`;
+
+  // Prompt phase
+  let prompt: string;
+  try {
+    prompt = await withRetry(
+      () => callGeneratePrompt(prompter),
+      (s) => isRealString(s, 10),
+      3,
+      `${label}:prompt:${prompter.name}`,
+    );
+  } catch (err: any) {
+    return {
+      pairingIndex: pairing.index,
+      roundNum,
+      prompter,
+      prompt: "",
+      modelA: pairing.modelA,
+      answerA: "",
+      modelB: pairing.modelB,
+      answerB: "",
+      votes: [],
+      votesA: 0,
+      votesB: 0,
+      winner: "tie",
+      error: `Prompt failed: ${err.message}`,
+    };
+  }
+
+  // Answer phase (parallel)
+  let answerA = "",
+    answerB = "";
+  try {
+    const [ansA, ansB] = await Promise.all([
+      withRetry(
+        () => callGenerateAnswer(pairing.modelA, prompt),
+        (s) => isRealString(s, 3),
+        3,
+        `${label}:answer:${pairing.modelA.name}`,
+      ),
+      withRetry(
+        () => callGenerateAnswer(pairing.modelB, prompt),
+        (s) => isRealString(s, 3),
+        3,
+        `${label}:answer:${pairing.modelB.name}`,
+      ),
+    ]);
+    answerA = ansA;
+    answerB = ansB;
+  } catch (err: any) {
+    return {
+      pairingIndex: pairing.index,
+      roundNum,
+      prompter,
+      prompt,
+      modelA: pairing.modelA,
+      answerA,
+      modelB: pairing.modelB,
+      answerB,
+      votes: [],
+      votesA: 0,
+      votesB: 0,
+      winner: "tie",
+      error: `Answer failed: ${err.message}`,
+    };
+  }
+
+  // Vote phase (parallel)
+  let votesA = 0;
+  let votesB = 0;
+  const roundVotes: { voter: Model; votedFor: "A" | "B" | null }[] = [];
+
+  await Promise.all(
+    voters.map(async (voter) => {
+      try {
+        const showAFirst = Math.random() > 0.5;
+        const first = showAFirst
+          ? { answer: answerA }
+          : { answer: answerB };
+        const second = showAFirst
+          ? { answer: answerB }
+          : { answer: answerA };
+
+        const result = await withRetry(
+          () => callVote(voter, prompt, first, second),
+          (v) => v === "A" || v === "B",
+          3,
+          `${label}:vote:${voter.name}`,
+        );
+
+        const votedForA = showAFirst ? result === "A" : result === "B";
+        if (votedForA) votesA++;
+        else votesB++;
+        roundVotes.push({ voter, votedFor: votedForA ? "A" : "B" });
+      } catch {
+        roundVotes.push({ voter, votedFor: null });
+      }
+    }),
+  );
+
+  const winner: "A" | "B" | "tie" =
+    votesA > votesB ? "A" : votesB > votesA ? "B" : "tie";
+
+  return {
+    pairingIndex: pairing.index,
+    roundNum,
+    prompter,
+    prompt,
+    modelA: pairing.modelA,
+    answerA,
+    modelB: pairing.modelB,
+    answerB,
+    votes: roundVotes,
+    votesA,
+    votesB,
+    winner,
+  };
+}
+
+// ── Main bench loop ────────────────────────────────────────────────────────
+
+export async function runBench(
+  config: BenchRunConfig,
+  onProgress: () => void,
+): Promise<string> {
+  if (activeBenchRun) {
+    throw new Error("A benchmark is already running");
+  }
+
+  const models = config.models;
+  const pairings = generatePairings(models);
+  const totalRounds = pairings.length * config.roundsPerPairing;
+  const runId = crypto.randomUUID();
+
+  const state: BenchRunState = {
+    id: runId,
+    status: "running",
+    config,
+    startedAt: Date.now(),
+    totalRounds,
+    completedRounds: 0,
+  };
+
+  activeBenchRun = state;
+  cancelFlag = false;
+
+  saveBenchRun({
+    id: runId,
+    status: "running",
+    config,
+    startedAt: state.startedAt,
+    totalRounds,
+  });
+
+  log("INFO", "bench", `Starting benchmark run ${runId}`, {
+    pairings: pairings.length,
+    roundsPerPairing: config.roundsPerPairing,
+    totalRounds,
+  });
+
+  onProgress();
+
+  try {
+    for (let pi = 0; pi < pairings.length; pi++) {
+      const pairing = pairings[pi]!;
+
+      for (let rn = 1; rn <= config.roundsPerPairing; rn++) {
+        if (cancelFlag) {
+          state.status = "cancelled";
+          state.finishedAt = Date.now();
+          updateBenchRunStatus(runId, {
+            status: "cancelled",
+            completedRounds: state.completedRounds,
+            finishedAt: state.finishedAt,
+          });
+          log("INFO", "bench", `Benchmark ${runId} cancelled`);
+          onProgress();
+          activeBenchRun = null;
+          return runId;
+        }
+
+        state.currentPairing = pairing;
+        state.currentRound = rn;
+        onProgress();
+
+        const result = await runBenchRound(pairing, rn, models);
+
+        saveBenchRound({
+          runId,
+          pairingIndex: pairing.index,
+          roundNum: rn,
+          data: result,
+        });
+
+        state.completedRounds++;
+        updateBenchRunStatus(runId, {
+          completedRounds: state.completedRounds,
+        });
+
+        onProgress();
+      }
+    }
+
+    state.status = "completed";
+    state.finishedAt = Date.now();
+    state.currentPairing = undefined;
+    state.currentRound = undefined;
+    updateBenchRunStatus(runId, {
+      status: "completed",
+      completedRounds: state.completedRounds,
+      finishedAt: state.finishedAt,
+    });
+
+    log("INFO", "bench", `Benchmark ${runId} completed`, {
+      completedRounds: state.completedRounds,
+    });
+    onProgress();
+  } catch (err: any) {
+    state.status = "error";
+    state.error = err.message;
+    state.finishedAt = Date.now();
+    updateBenchRunStatus(runId, {
+      status: "error",
+      completedRounds: state.completedRounds,
+      finishedAt: state.finishedAt,
+      error: err.message,
+    });
+    log("ERROR", "bench", `Benchmark ${runId} failed`, {
+      error: err.message,
+    });
+    onProgress();
+  } finally {
+    activeBenchRun = null;
+  }
+
+  return runId;
+}

--- a/bench.ts
+++ b/bench.ts
@@ -96,6 +96,23 @@ async function runBenchRound(
   const nonContestants = allModels.filter(
     (m) => m.id !== pairing.modelA.id && m.id !== pairing.modelB.id,
   );
+  if (nonContestants.length === 0) {
+    return {
+      pairingIndex: pairing.index,
+      roundNum,
+      prompter: pairing.modelA,
+      prompt: "",
+      modelA: pairing.modelA,
+      answerA: "",
+      modelB: pairing.modelB,
+      answerB: "",
+      votes: [],
+      votesA: 0,
+      votesB: 0,
+      winner: "tie",
+      error: "Not enough models for prompter/voters",
+    };
+  }
   const shuffledNon = shuffle([...nonContestants]);
   const prompter = shuffledNon[0]!;
   const voters = shuffledNon; // all non-contestants vote (including prompter)

--- a/frontend.tsx
+++ b/frontend.tsx
@@ -352,6 +352,9 @@ function Standings({
           <a href="/history" className="standings__link">
             History
           </a>
+          <a href="/bench" className="standings__link">
+            Bench
+          </a>
           <a href="https://twitch.tv/quipslop" target="_blank" rel="noopener noreferrer" className="standings__link">
             Twitch
           </a>

--- a/server.ts
+++ b/server.ts
@@ -4,6 +4,7 @@ import indexHtml from "./index.html";
 import historyHtml from "./history.html";
 import adminHtml from "./admin.html";
 import broadcastHtml from "./broadcast.html";
+import benchHtml from "./bench.html";
 import { clearAllRounds, getRounds, getAllRounds } from "./db.ts";
 import {
   MODELS,
@@ -13,6 +14,13 @@ import {
   type GameState,
   type RoundState,
 } from "./game.ts";
+import { runBench, getActiveBenchRun, cancelBench } from "./bench.ts";
+import {
+  getBenchRuns,
+  getBenchRun,
+  getBenchRounds,
+  markStaleBenchRunsAsError,
+} from "./bench-db.ts";
 
 const VERSION = crypto.randomUUID().slice(0, 8);
 
@@ -217,6 +225,21 @@ function setHistoryCache(key: string, body: string, expiresAt: number) {
 
 const clients = new Set<ServerWebSocket<WsData>>();
 
+function getBenchSummary() {
+  const active = getActiveBenchRun();
+  if (!active) return null;
+  return {
+    id: active.id,
+    status: active.status,
+    totalRounds: active.totalRounds,
+    completedRounds: active.completedRounds,
+    currentPairing: active.currentPairing
+      ? { modelA: active.currentPairing.modelA, modelB: active.currentPairing.modelB }
+      : undefined,
+    currentRound: active.currentRound,
+  };
+}
+
 function getClientState() {
   return {
     active: gameState.active,
@@ -235,6 +258,7 @@ function broadcast() {
     totalRounds: runs,
     viewerCount: clients.size,
     version: VERSION,
+    bench: getBenchSummary(),
   });
   for (const ws of clients) {
     ws.send(msg);
@@ -259,6 +283,7 @@ function getAdminSnapshot() {
     completedInMemory: gameState.completed.length,
     persistedRounds: getRounds(1, 1).total,
     viewerCount: clients.size,
+    bench: getBenchSummary(),
   };
 }
 
@@ -273,6 +298,7 @@ const server = Bun.serve<WsData>({
     "/history": historyHtml,
     "/admin": adminHtml,
     "/broadcast": broadcastHtml,
+    "/bench": benchHtml,
   },
   async fetch(req, server) {
     const url = new URL(req.url);
@@ -483,6 +509,95 @@ const server = Bun.serve<WsData>({
       );
     }
 
+    // ── Bench API endpoints ──
+    if (url.pathname === "/api/bench/start") {
+      if (req.method !== "POST") {
+        return new Response("Method Not Allowed", { status: 405, headers: { Allow: "POST" } });
+      }
+      if (isRateLimited(`admin:${ip}`, ADMIN_LIMIT_PER_MIN, WINDOW_MS)) {
+        return new Response("Too Many Requests", { status: 429 });
+      }
+      if (!isAdminAuthorized(req, url)) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+      if (getActiveBenchRun()) {
+        return new Response(JSON.stringify({ error: "A benchmark is already running" }), {
+          status: 409,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      let roundsPerPairing = 1;
+      try {
+        const body = await req.json();
+        const rpp = Number((body as Record<string, unknown>).roundsPerPairing);
+        if (Number.isFinite(rpp) && rpp >= 1 && rpp <= 10) {
+          roundsPerPairing = Math.floor(rpp);
+        }
+      } catch {}
+
+      const config = { models: [...MODELS], roundsPerPairing };
+      runBench(config, broadcast).catch((err) => {
+        log("ERROR", "bench", "Bench run failed", { error: err.message });
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+      const active = getActiveBenchRun();
+      return new Response(JSON.stringify({ ok: true, runId: active?.id }), {
+        status: 200,
+        headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+      });
+    }
+
+    if (url.pathname === "/api/bench/cancel") {
+      if (req.method !== "POST") {
+        return new Response("Method Not Allowed", { status: 405, headers: { Allow: "POST" } });
+      }
+      if (isRateLimited(`admin:${ip}`, ADMIN_LIMIT_PER_MIN, WINDOW_MS)) {
+        return new Response("Too Many Requests", { status: 429 });
+      }
+      if (!isAdminAuthorized(req, url)) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+      const cancelled = cancelBench();
+      return new Response(JSON.stringify({ ok: true, cancelled }), {
+        status: 200,
+        headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+      });
+    }
+
+    if (url.pathname === "/api/bench/status") {
+      const active = getActiveBenchRun();
+      return new Response(JSON.stringify({ active: active ? getBenchSummary() : null }), {
+        status: 200,
+        headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+      });
+    }
+
+    if (url.pathname === "/api/bench/runs") {
+      const benchRuns = getBenchRuns();
+      return new Response(JSON.stringify(benchRuns), {
+        status: 200,
+        headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+      });
+    }
+
+    if (url.pathname.startsWith("/api/bench/results/")) {
+      const runId = url.pathname.slice("/api/bench/results/".length);
+      if (!runId) {
+        return new Response("Missing run ID", { status: 400 });
+      }
+      const run = getBenchRun(runId);
+      if (!run) {
+        return new Response("Not found", { status: 404 });
+      }
+      const rounds = getBenchRounds(runId);
+      return new Response(JSON.stringify({ run, rounds }), {
+        status: 200,
+        headers: { "Content-Type": "application/json", "Cache-Control": "no-store" },
+      });
+    }
+
     if (url.pathname === "/api/history") {
       if (isRateLimited(`history:${ip}`, HISTORY_LIMIT_PER_MIN, WINDOW_MS)) {
         log("WARN", "http", "History rate limited", { ip });
@@ -615,6 +730,9 @@ const server = Bun.serve<WsData>({
     return new Response("Internal Server Error", { status: 500 });
   },
 });
+
+// Mark stale bench runs from previous crashes
+markStaleBenchRunsAsError();
 
 console.log(`\n🎮 quipslop Web — http://localhost:${server.port}`);
 console.log(`📡 WebSocket — ws://localhost:${server.port}/ws`);


### PR DESCRIPTION
## Summary
- Adds a systematic **round-robin benchmark** mode where every model plays against every other model (C(7,2) = 21 matchups with 7 models)
- Results are persisted to SQLite and displayed on a dedicated `/bench` page with overall rankings and a color-coded head-to-head matrix
- Benchmark can be started/cancelled from the admin panel with configurable rounds-per-pairing (1/3/5)

## Details

**New files:**
- `bench-db.ts` — Database layer (`bench_runs` + `bench_rounds` tables, crash recovery)
- `bench.ts` — Benchmark engine (pairing generation, round execution reusing existing `game.ts` exports)
- `bench.html` + `bench.css` + `bench-frontend.tsx` — Frontend with rankings table, head-to-head matrix, matchup detail view, real-time WebSocket progress

**Modified files:**
- `server.ts` — `/bench` route, bench API endpoints (`/api/bench/start|cancel|status|runs|results/:id`), bench status in WS broadcast, startup crash recovery
- `frontend.tsx` — "Bench" link in standings nav
- `admin.tsx` — Benchmark section with start/cancel controls and progress display

**Edge cases handled:**
- Only one bench at a time (409 conflict)
- Graceful cancel between rounds, partial results preserved
- Per-round retry (3 attempts), failed rounds recorded with error
- Server restart marks stale running bench runs as error

## Test plan
- [ ] Start server with `bun --hot server.ts`
- [ ] Navigate to `/admin`, start a benchmark (1 round/pairing)
- [ ] Navigate to `/bench`, verify progress bar updates in real-time via WebSocket
- [ ] After completion, verify rankings table and head-to-head matrix
- [ ] Click a matrix cell to see matchup details (prompt, answers, votes)
- [ ] Test cancel mid-run, verify partial results preserved
- [ ] Restart server, verify stale running bench is marked as error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full benchmarking system to run, track, and persist model comparison runs.
  * Start/cancel benchmark runs from Admin with configurable rounds per pairing.
  * Dedicated Benchmark UI page with dark-themed layout, run selector, progress, and past runs.
  * Results view: overall rankings, head‑to‑head matrix, and round‑by‑round matchup detail.
  * Real‑time updates during active runs and historical results browsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->