### PR TITLE
Added resizable sidebar with position toggle

### DIFF
--- a/frontend.css
+++ b/frontend.css
@@ -713,7 +713,7 @@ body {
     width: 100%;
     border-top: 1px solid var(--border);
     border-left: none;
-    max-height: 200px;
+    max-height: 400px;
     padding: 16px 48px;
   }
 

--- a/frontend.tsx
+++ b/frontend.tsx
@@ -392,7 +392,7 @@ function Standings({
       <div
         ref={resizeRef}
         className={`standings__resize-handle standings__resize-handle--${position}`}
-        onMouseDown={() => setIsResizing(true)}
+        onMouseDown={(e) => { e.preventDefault(); setIsResizing(true); }}
       />
       <div className="standings__head">
         <span className="standings__title">Standings</span>
@@ -471,9 +471,11 @@ function App() {
   const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT_WIDTH);
 
   const toggleSidebarPosition = useCallback(() => {
-    setSidebarPosition((p) => (p === "side" ? "bottom" : "side"));
-    setSidebarWidth(sidebarPosition === "side" ? 180 : SIDEBAR_DEFAULT_WIDTH);
-  }, [sidebarPosition]);
+    setSidebarPosition((p) => {
+      setSidebarWidth(p === "side" ? 180 : SIDEBAR_DEFAULT_WIDTH);
+      return p === "side" ? "bottom" : "side";
+    });
+  }, []);
 
   useEffect(() => {
     const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";


### PR DESCRIPTION
- Sidebar can be resized by dragging the edge (side: left edge, bottom: top edge)
- Added toggle button to move sidebar between side and bottom positions
- Bottom position displays standings in a horizontal grid layout
- Side position maintains vertical list with configurable width (200-500px)
- Bottom position height configurable (120-400px)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standings area is resizable with drag handles for both side and bottom positions, including hover interactions.
  * Toggle control to switch standings between side and bottom layouts.
  * New bottom standings section with its own layout, borders and max-height behavior.
  * Layout adjustments ensure proper spacing, padding and responsive behavior for large viewports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->