### PR TITLE
added win streaks, Maria will be happy :)

### DIFF
--- a/broadcast.ts
+++ b/broadcast.ts
@@ -29,6 +29,7 @@ type GameState = {
   lastCompleted: RoundState | null;
   active: RoundState | null;
   scores: Record<string, number>;
+  streaks: Record<string, number>;
   done: boolean;
   isPaused: boolean;
   generation: number;
@@ -291,9 +292,9 @@ function drawHeader() {
 
 }
 
-function drawScoreboard(scores: Record<string, number>) {
+function drawScoreboard(scores: Record<string, number>, streaks: Record<string, number>) {
   const entries = Object.entries(scores).sort((a, b) => b[1] - a[1]);
-  
+
   roundRect(WIDTH - 380, 0, 380, HEIGHT, 0, "#111");
   ctx.fillStyle = "#1c1c1c";
   ctx.fillRect(WIDTH - 380, 0, 1, HEIGHT);
@@ -335,6 +336,15 @@ function drawScoreboard(scores: Record<string, number>) {
     const scoreText = String(score);
     const scoreWidth = ctx.measureText(scoreText).width;
     ctx.fillText(scoreText, WIDTH - 48 - scoreWidth, y + 24);
+
+    const streak = streaks[name] || 0;
+    if (streak >= 2) {
+      ctx.font = '600 16px "Inter", sans-serif';
+      ctx.fillStyle = "#f59e0b";
+      const streakText = `🔥${streak}`;
+      const streakWidth = ctx.measureText(streakText).width;
+      ctx.fillText(streakText, WIDTH - 48 - scoreWidth - streakWidth - 8, y + 24);
+    }
   });
 }
 
@@ -564,7 +574,7 @@ function draw() {
       return;
   }
 
-  drawScoreboard(state.scores);
+  drawScoreboard(state.scores, state.streaks);
   
   const isNextPrompting = state.active?.phase === "prompting" && !state.active.prompt;
   const displayRound = isNextPrompting && state.lastCompleted ? state.lastCompleted : (state.active ?? state.lastCompleted ?? null);

--- a/frontend.css
+++ b/frontend.css
@@ -220,6 +220,15 @@ body {
   flex-shrink: 0;
 }
 
+.streak-badge {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 6px;
+  color: #f59e0b;
+  margin-left: auto;
+}
+
 .win-tag {
   font-family: var(--mono);
   font-size: 10px;
@@ -417,6 +426,14 @@ body {
   height: 100%;
   border-radius: 2px;
   transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.standing__streak {
+  font-size: 11px;
+  font-weight: 700;
+  color: #f59e0b;
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 .standing__score {

--- a/frontend.tsx
+++ b/frontend.tsx
@@ -35,6 +35,7 @@ type GameState = {
   lastCompleted: RoundState | null;
   active: RoundState | null;
   scores: Record<string, number>;
+  streaks: Record<string, number>;
   done: boolean;
   isPaused: boolean;
   generation: number;
@@ -155,6 +156,7 @@ function ContestantCard({
   isWinner,
   showVotes,
   voters,
+  streak,
 }: {
   task: TaskInfo;
   voteCount: number;
@@ -162,6 +164,7 @@ function ContestantCard({
   isWinner: boolean;
   showVotes: boolean;
   voters: VoteInfo[];
+  streak: number;
 }) {
   const color = getColor(task.model.name);
   const pct = totalVotes > 0 ? Math.round((voteCount / totalVotes) * 100) : 0;
@@ -173,6 +176,11 @@ function ContestantCard({
     >
       <div className="contestant__head">
         <ModelTag model={task.model} />
+        {streak >= 2 && (
+          <span className="streak-badge" title={`${streak} win streak`}>
+            🔥 {streak}
+          </span>
+        )}
         {isWinner && <span className="win-tag">WIN</span>}
       </div>
 
@@ -235,7 +243,7 @@ function ContestantCard({
 
 // ── Arena ─────────────────────────────────────────────────────────────────────
 
-function Arena({ round, total }: { round: RoundState; total: number | null }) {
+function Arena({ round, total, streaks }: { round: RoundState; total: number | null; streaks: Record<string, number> }) {
   const [contA, contB] = round.contestants;
   const showVotes = round.phase === "voting" || round.phase === "done";
   const isDone = round.phase === "done";
@@ -280,6 +288,7 @@ function Arena({ round, total }: { round: RoundState; total: number | null }) {
             isWinner={isDone && votesA > votesB}
             showVotes={showVotes}
             voters={votersA}
+            streak={streaks[contA.name] || 0}
           />
           <ContestantCard
             task={round.answerTasks[1]}
@@ -288,6 +297,7 @@ function Arena({ round, total }: { round: RoundState; total: number | null }) {
             isWinner={isDone && votesB > votesA}
             showVotes={showVotes}
             voters={votersB}
+            streak={streaks[contB.name] || 0}
           />
         </div>
       )}
@@ -329,9 +339,11 @@ function GameOver({ scores }: { scores: Record<string, number> }) {
 
 function Standings({
   scores,
+  streaks,
   activeRound,
 }: {
   scores: Record<string, number>;
+  streaks: Record<string, number>;
   activeRound: RoundState | null;
 }) {
   const sorted = Object.entries(scores).sort((a, b) => b[1] - a[1]);
@@ -380,6 +392,11 @@ function Standings({
                   style={{ width: `${pct}%`, background: color }}
                 />
               </div>
+              {(streaks[name] || 0) >= 2 && (
+                <span className="standing__streak" title={`${streaks[name]} win streak`}>
+                  🔥{streaks[name]}
+                </span>
+              )}
               <span className="standing__score">{score}</span>
             </div>
           );
@@ -484,7 +501,7 @@ function App() {
           {state.done ? (
             <GameOver scores={state.scores} />
           ) : displayRound ? (
-            <Arena round={displayRound} total={totalRounds} />
+            <Arena round={displayRound} total={totalRounds} streaks={state.streaks} />
           ) : (
             <div className="waiting">
               Starting
@@ -501,7 +518,7 @@ function App() {
           )}
         </main>
 
-        <Standings scores={state.scores} activeRound={state.active} />
+        <Standings scores={state.scores} streaks={state.streaks} activeRound={state.active} />
       </div>
     </div>
   );

--- a/game.ts
+++ b/game.ts
@@ -70,6 +70,7 @@ export type GameState = {
   completed: RoundState[];
   active: RoundState | null;
   scores: Record<string, number>;
+  streaks: Record<string, number>;
   done: boolean;
   isPaused: boolean;
   generation: number;
@@ -453,8 +454,15 @@ export async function runGame(
     round.phase = "done";
     if (votesA > votesB) {
       state.scores[contA.name] = (state.scores[contA.name] || 0) + 1;
+      state.streaks[contA.name] = (state.streaks[contA.name] || 0) + 1;
+      state.streaks[contB.name] = 0;
     } else if (votesB > votesA) {
       state.scores[contB.name] = (state.scores[contB.name] || 0) + 1;
+      state.streaks[contB.name] = (state.streaks[contB.name] || 0) + 1;
+      state.streaks[contA.name] = 0;
+    } else {
+      state.streaks[contA.name] = 0;
+      state.streaks[contB.name] = 0;
     }
     rerender();
 

--- a/quipslop.tsx
+++ b/quipslop.tsx
@@ -224,6 +224,7 @@ function Game({ runs }: { runs: number }) {
     completed: [],
     active: null,
     scores: Object.fromEntries(MODELS.map((m) => [m.name, 0])),
+    streaks: {},
     done: false,
     isPaused: false,
     generation: 0,

--- a/server.ts
+++ b/server.ts
@@ -30,17 +30,25 @@ if (!process.env.OPENROUTER_API_KEY) {
 
 const allRounds = getAllRounds();
 const initialScores = Object.fromEntries(MODELS.map((m) => [m.name, 0]));
+const initialStreaks: Record<string, number> = {};
 
 let initialCompleted: RoundState[] = [];
 if (allRounds.length > 0) {
   for (const round of allRounds) {
     if (round.scoreA !== undefined && round.scoreB !== undefined) {
+      const contAName = round.contestants[0].name;
+      const contBName = round.contestants[1].name;
       if (round.scoreA > round.scoreB) {
-        initialScores[round.contestants[0].name] =
-          (initialScores[round.contestants[0].name] || 0) + 1;
+        initialScores[contAName] = (initialScores[contAName] || 0) + 1;
+        initialStreaks[contAName] = (initialStreaks[contAName] || 0) + 1;
+        initialStreaks[contBName] = 0;
       } else if (round.scoreB > round.scoreA) {
-        initialScores[round.contestants[1].name] =
-          (initialScores[round.contestants[1].name] || 0) + 1;
+        initialScores[contBName] = (initialScores[contBName] || 0) + 1;
+        initialStreaks[contBName] = (initialStreaks[contBName] || 0) + 1;
+        initialStreaks[contAName] = 0;
+      } else {
+        initialStreaks[contAName] = 0;
+        initialStreaks[contBName] = 0;
       }
     }
   }
@@ -54,6 +62,7 @@ const gameState: GameState = {
   completed: initialCompleted,
   active: null,
   scores: initialScores,
+  streaks: initialStreaks,
   done: false,
   isPaused: false,
   generation: 0,
@@ -224,6 +233,7 @@ function getClientState() {
     active: gameState.active,
     lastCompleted: gameState.completed.at(-1) ?? null,
     scores: gameState.scores,
+    streaks: gameState.streaks,
     done: gameState.done,
     isPaused: gameState.isPaused,
     generation: gameState.generation,
@@ -434,6 +444,7 @@ const server = Bun.serve<WsData>({
       gameState.completed = [];
       gameState.active = null;
       gameState.scores = Object.fromEntries(MODELS.map((m) => [m.name, 0]));
+      gameState.streaks = {};
       gameState.done = false;
       gameState.isPaused = true;
       gameState.generation += 1;


### PR DESCRIPTION
pretty explanatory from the title, i do have written a test, not sure if was good to merge tho
<img width="1198" height="491" alt="image" src="https://github.com/user-attachments/assets/b233d229-0161-4022-aac9-68d3af83bdca" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-player streak tracking that counts consecutive wins.
  * Streaks display with a visual badge (flame emoji and highlighting) when a player reaches 2+ consecutive wins.
  * Streaks reset to zero on losses or ties.
  * Streak indicators appear in both the live arena view and leaderboard standings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->