### PR TITLE
perf: less deterministic AI — add temperature + split reasoning effort

### DIFF
--- a/game.ts
+++ b/game.ts
@@ -81,7 +81,16 @@ const openrouter = createOpenRouter({
   apiKey: process.env.OPENROUTER_API_KEY,
   extraBody: {
     reasoning: {
-      effort: "medium",
+      effort: "high",
+    },
+  },
+});
+
+const openrouterJudge = createOpenRouter({
+  apiKey: process.env.OPENROUTER_API_KEY,
+  extraBody: {
+    reasoning: {
+      effort: "low",
     },
   },
 });
@@ -204,6 +213,7 @@ export async function callGeneratePrompt(model: Model): Promise<string> {
     system,
     prompt:
       "Generate a single original Quiplash prompt. Be creative and don't repeat common patterns.",
+    temperature: 1.2,
   });
 
   log("INFO", `prompt:${model.name}`, "Raw response", {
@@ -225,6 +235,7 @@ export async function callGenerateAnswer(
     model: openrouter.chat(model.id),
     system: `You are playing Quiplash! You'll be given a fill-in-the-blank prompt. Give the FUNNIEST possible answer. Be creative, edgy, unexpected, and concise. Reply with ONLY your answer — no quotes, no explanation, no preamble. Keep it short (under 12 words). Keep it concise and witty.`,
     prompt: `Fill in the blank: ${prompt}`,
+    temperature: 1.3,
   });
 
   log("INFO", `answer:${model.name}`, "Raw response", {
@@ -247,7 +258,8 @@ export async function callVote(
     answerB: b.answer,
   });
   const { text, usage, reasoning } = await generateText({
-    model: openrouter.chat(voter.id),
+    model: openrouterJudge.chat(voter.id),
+    temperature: 0.3,
     system: `You are a judge in a comedy game. You'll see a fill-in-the-blank prompt and two answers. Pick which answer is FUNNIER. You MUST respond with exactly "A" or "B" — nothing else.`,
     prompt: `Prompt: "${prompt}"\n\nAnswer A: "${a.answer}"\nAnswer B: "${b.answer}"\n\nWhich is funnier? Reply with just A or B.`,
   });


### PR DESCRIPTION
## The problem

Same models + same prompt patterns + no temperature = same jokes every round. The game feels repetitive because all AI calls use default sampling parameters and `reasoning.effort: "medium"` globally.

## The fix (6 lines)

1. **`temperature: 1.2`** on prompt generation — more diverse prompts
2. **`temperature: 1.3`** on answer generation — wilder, less predictable jokes
3. **`temperature: 0.3`** on voting — judges stay decisive, not random
4. **`reasoning.effort: "high"`** for creative calls — models think harder about comedy
5. **`reasoning.effort: "low"`** for voting — judges don't need deep reasoning to pick A or B

## Why these values

- Creative calls get high temperature (1.2-1.3) because comedy benefits from surprising outputs. Default temperatures (~0.7) produce safe, predictable humor.
- Voting gets low temperature (0.3) because judges should be consistent, not flip-floppy.
- Reasoning effort split: "high" gives creative models more room to explore, "low" keeps voting fast and cheap.

## What changed

| Function | Before | After |
|----------|--------|-------|
| `callGeneratePrompt` | no temp, medium effort | temp 1.2, high effort |
| `callGenerateAnswer` | no temp, medium effort | temp 1.3, high effort |
| `callVote` | no temp, medium effort | temp 0.3, low effort |