### PR TITLE
fix(security): prevent path traversal in /assets/ endpoint

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,6 @@
 import type { ServerWebSocket } from "bun";
 import { timingSafeEqual } from "node:crypto";
+import { resolve, relative } from "node:path";
 import indexHtml from "./index.html";
 import historyHtml from "./history.html";
 import adminHtml from "./admin.html";
@@ -115,6 +116,7 @@ const VIEWER_VOTE_BROADCAST_DEBOUNCE_MS = parsePositiveInt(
 );
 const ADMIN_COOKIE = "quipslop_admin";
 const ADMIN_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+const PUBLIC_DIR = resolve("./public");
 
 const requestWindows = new Map<string, number[]>();
 const wsByIp = new Map<string, number>();
@@ -423,8 +425,16 @@ const server = Bun.serve<WsData>({
     const ip = getClientIp(req, server);
 
     if (url.pathname.startsWith("/assets/")) {
-      const path = `./public${url.pathname}`;
-      const file = Bun.file(path);
+      const assetPath = url.pathname.slice(8);
+      if (!assetPath) {
+        return new Response("Not found", { status: 404 });
+      }
+      const resolved = resolve(PUBLIC_DIR, assetPath);
+      const relativePath = relative(PUBLIC_DIR, resolved);
+      if (relativePath.startsWith("..") || relativePath === "..") {
+        return new Response("Forbidden", { status: 403 });
+      }
+      const file = Bun.file(resolved);
       return new Response(file, {
         headers: {
           "Cache-Control": "public, max-age=604800, immutable",


### PR DESCRIPTION
## Summary

Fixes a path traversal vulnerability in the `/assets/` endpoint that could allow reading arbitrary files on the server.

## Vulnerability Details

The original code concatenated the URL pathname directly to `./public` without validation:
```javascript
const path = `./public${url.pathname}`;
```

This allowed attackers to request paths like `/assets/../.env` or `/assets/../server.ts` to read sensitive files outside the public directory.

## Fix

- Resolve the path using `node:path/resolve`
- Validate that the resolved path starts with the public directory
- Return 403 Forbidden if the path escapes the intended directory

## Testing

Tested the following scenarios:
- `/assets/logo.svg` → ✅ Returns file
- `/assets/../server.ts` → ✅ Returns 403 Forbidden
- `/assets/..%2Fserver.ts` → ✅ Returns 403 Forbidden

## Notes

While the live site currently has CDN-level path normalization that mitigates this, the vulnerability exists in the code itself and would be exploitable if:
- CDN/proxy configuration changes
- Deployed on different infrastructure
- Run locally in development mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset-serving validation to block attempts to access files outside the public assets directory.
  * Requests that try to traverse outside the public folder are now rejected with a forbidden response.
  * Missing or empty asset requests now return a not-found response, while caching behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->