### PR TITLE
Remove deepseek, add flash, llama and qwen.

### DIFF
--- a/game.ts
+++ b/game.ts
@@ -25,9 +25,11 @@ export type Model = (typeof MODELS)[number];
 
 export const MODEL_COLORS: Record<string, string> = {
   "Gemini 3.1 Pro": "cyan",
+  "Gemini 3 Flash": "blueBright",
+  "Llama 4 Maverick": "yellowBright",
+  "Qwen 3.5 Plus": "redBright",
   "Kimi K2": "green",
   "Kimi K2.5": "magenta",
-  "DeepSeek 3.2": "greenBright",
   "GLM-5": "cyanBright",
   "GPT-5.2": "yellow",
   "Opus 4.6": "blue",

--- a/game.ts
+++ b/game.ts
@@ -7,9 +7,12 @@ import { join } from "node:path";
 
 export const MODELS = [
   { id: "google/gemini-3.1-pro-preview", name: "Gemini 3.1 Pro" },
+  { id: "google/gemini-3-flash-preview", name: "Gemini 3 Flash" },
+  { id: "meta-llama/llama-4-maverick", name: "Llama 4 Maverick" },
+  { id: "qwen/qwen3.5-plus-02-15", name: "Qwen 3.5 Plus" },
   { id: "moonshotai/kimi-k2", name: "Kimi K2" },
   // { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5" },
-  { id: "deepseek/deepseek-v3.2", name: "DeepSeek 3.2" },
+  // { id: "deepseek/deepseek-v3.2", name: "DeepSeek 3.2" },
   // { id: "z-ai/glm-5", name: "GLM-5" },
   { id: "openai/gpt-5.2", name: "GPT-5.2" },
   { id: "anthropic/claude-opus-4.6", name: "Opus 4.6" },


### PR DESCRIPTION
Deepseek is slow, swap it for some new models.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `game.ts` to remove DeepSeek 3.2 and add Gemini 3 Flash, Llama 4 Maverick, and Qwen 3.5 Plus to `MODELS` and `MODEL_COLORS`
> Add three model entries and corresponding color mappings in [game.ts](https://github.com/T3-Content/quipslop/pull/44/files#diff-a8e9787d50df328450841dd413656e542f9854afaecbe407ddce6cf45ef65372) and remove the DeepSeek 3.2 entry and mapping.
>
> #### 📍Where to Start
> Start with the `MODELS` and `MODEL_COLORS` constants in [game.ts](https://github.com/T3-Content/quipslop/pull/44/files#diff-a8e9787d50df328450841dd413656e542f9854afaecbe407ddce6cf45ef65372).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea95fdf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new AI models: Gemini 3 Flash, Llama 4 Maverick, and Qwen 3.5 Plus.

* **Updates**
  * DeepSeek 3.2 has been retired and is no longer available.
  * UI model color themes updated to include distinct colors for the three new models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->